### PR TITLE
Initiated segment_category_ids_any var

### DIFF
--- a/third_party/url_helper/ext.url_helper.php
+++ b/third_party/url_helper/ext.url_helper.php
@@ -159,6 +159,7 @@ class Url_helper_ext {
         $site = $this->EE->config->item('site_id');
         $data = $cats = $segs = array();
         $data[$this->prefix.'segment_category_ids'] = '';
+        $data[$this->prefix.'segment_category_ids_any'] = '';
         
         // loop through segments and set data array thus: segment_1_category_id etc
         foreach ($this->EE->uri->segments AS $nr => $seg)


### PR DESCRIPTION
Otherwise {segment_category_ids_any} outputs the tag “{segment_category_ids_any}” when the URL does not contain categories. See https://github.com/litzinger/URL-Helper/issues/3
